### PR TITLE
fix(execute): repair worktree provisioning, state truncation, and orchestrator doc

### DIFF
--- a/agents/babyclaude.md
+++ b/agents/babyclaude.md
@@ -1,5 +1,3 @@
-
-
 ---
 name: babyclaude
 description: |
@@ -64,7 +62,7 @@ hooks:
   Stop:
     - hooks:
         - type: prompt
-          prompt: "Evaluate if the babyclaude task implementation is complete. This is a HARD GATE - do not allow incomplete work through. Check ALL criteria: 1) All acceptance criteria addressed - not just attempted, actually complete, 2) Code compiles/lints clean, 3) Tests pass if applicable, 4) No incomplete TODOs or placeholder code, 5) Output JSON valid with all required fields. Return {\"ok\": true} ONLY if ALL criteria met. Return {\"ok\": false, \"reason\": \"specific issue\"} if ANY work remains. Be strict."
+          prompt: 'Evaluate if the babyclaude task implementation is complete. This is a HARD GATE - do not allow incomplete work through. Check ALL criteria: 1) All acceptance criteria addressed - not just attempted, actually complete, 2) Code compiles/lints clean, 3) Tests pass if applicable, 4) No incomplete TODOs or placeholder code, 5) Output JSON valid with all required fields. Return {"ok": true} ONLY if ALL criteria met. Return {"ok": false, "reason": "specific issue"} if ANY work remains. Be strict.'
           timeout: 30
         - type: command
           command: "${CLAUDE_PLUGIN_ROOT}/hooks/task-completion-capture.sh"
@@ -144,6 +142,40 @@ When you discover something OUT OF SCOPE:
 3. **Continue** - Complete your assigned task
 
 ## Implementation Workflow
+
+### Step 0: Locate Your Worktree (CRITICAL)
+
+The orchestrator provisions an isolated git worktree for you via a `SubagentStart`
+hook. Some Claude Code versions inject the worktree path as a system message at
+session start; others do not. Either way, the canonical source of truth is the
+`execute-state.json` file.
+
+Before touching any file, do this:
+
+1. Locate the project root by reading the `cwd` you were spawned in (your default
+   Bash `pwd`). The state file is at `${cwd}/.claude/execute-state.json`.
+2. Read `current_task` from the state — that's your task ID.
+3. Read `tasks[] | select(.id == "<task_id>") | .worktree_path` — that's your
+   isolated working directory (typically under `/tmp/kernel-worktrees/`).
+
+```bash
+TASK_ID=$(jq -r '.current_task' .claude/execute-state.json)
+WORKTREE=$(jq -r --arg id "$TASK_ID" '(.tasks[] | select(.id==$id)).worktree_path' .claude/execute-state.json)
+echo "$WORKTREE"
+```
+
+4. **All file operations (Read, Write, Edit) MUST use absolute paths inside
+   `$WORKTREE`.** Do not write to the main repo at the parent `cwd`.
+5. For Bash commands, prefix with `cd "$WORKTREE" && ...` or use absolute paths.
+
+If `current_task` is null or no worktree_path is set, output:
+
+```json
+{
+  "status": "blocked",
+  "reason": "Worktree not provisioned — check SubagentStart hook"
+}
+```
 
 ### Step 1: Understand Context
 

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -62,17 +62,17 @@ You are orchestrating a task execution workflow with isolated agents and human c
 
 ## Flags
 
-| Flag            | Effect                                              |
-| --------------- | --------------------------------------------------- |
-| `--resume`      | Resume from last checkpoint                         |
-| `--status`      | Show current execution status                       |
-| `--abort`       | Abort current execution (saves checkpoint)          |
-| `--batch N`     | Override batch size (default: from plan)            |
-| `--model M`     | Model for agents: `opus` or `sonnet` (default: opus)|
-| `--skip-review` | Skip code review (spec review still runs)           |
-| `--dry-run`     | Parse plan and show execution order without running |
-| `--timing`      | Show task and batch durations                       |
-| `--trace`       | Show execution trace at completion                  |
+| Flag            | Effect                                               |
+| --------------- | ---------------------------------------------------- |
+| `--resume`      | Resume from last checkpoint                          |
+| `--status`      | Show current execution status                        |
+| `--abort`       | Abort current execution (saves checkpoint)           |
+| `--batch N`     | Override batch size (default: from plan)             |
+| `--model M`     | Model for agents: `opus` or `sonnet` (default: opus) |
+| `--skip-review` | Skip code review (spec review still runs)            |
+| `--dry-run`     | Parse plan and show execution order without running  |
+| `--timing`      | Show task and batch durations                        |
+| `--trace`       | Show execution trace at completion                   |
 
 ## Merge Strategy
 
@@ -151,6 +151,34 @@ AskUserQuestion({
 ```
 
 Store the selected model in `execute-state.json` as `"model": "opus"|"sonnet"`. All `Task()` calls for babyclaude, spec-reviewer, and code-reviewer must use this value.
+
+### Pre-flight: gitignore ephemeral state
+
+The `create-task-branch.sh` hook refuses to create a worktree if the working
+tree is dirty (`git diff-index --quiet HEAD --`). The orchestrator writes to
+`.claude/execute-state.json`, `.claude/traces/`, and `.claude/checkpoints/`
+between every spawn, so if those paths are tracked, the hook will block from
+the second task onwards.
+
+If `.claude/.gitignore` is missing, create one with:
+
+```
+execute-state.json
+execute-trace.json
+checkpoints/
+traces/
+task-outputs/
+agent-outputs/
+reviews/
+errors/
+evidence/
+verification/
+tmp/
+SCOPE_NOTES.md
+```
+
+and commit it (along with `git rm --cached` of any of those paths that are
+already tracked) BEFORE Phase 1.
 
 ### Plan Loading
 
@@ -275,115 +303,187 @@ Tasks in this batch:
 
 For each task in batch:
 
-### 2.1 Branch Creation (via create-task-branch.sh hook)
+### 2.1 Write `current_task` to state (orchestrator, BEFORE spawn)
+
+**CRITICAL — do this before every babyclaude spawn.**
+
+The `SubagentStart` hook (`create-task-branch.sh`) needs to know which task it's
+provisioning a worktree for. The Claude Code hook stdin JSON does NOT contain
+the spawn prompt, so the hook cannot extract `TASK_ID` from there. Instead the
+hook reads `current_task` from `execute-state.json`.
+
+Therefore the orchestrator MUST write the current task ID into state immediately
+before calling `Task(babyclaude, ...)`:
+
+```typescript
+// MANDATORY: set current_task in state before spawning
+const stateFile = `${projectDir}/.claude/execute-state.json`;
+const state = JSON.parse(readFileSync(stateFile, "utf8"));
+state.current_task = task.id; // string ID, e.g. "1" or "auth-mw"
+state.status = "executing"; // hook bails if not "executing"
+writeFileSync(stateFile, JSON.stringify(state, null, 2));
+```
+
+Skipping this step is the single most common cause of "the worktree wasn't
+created" failures. The hook silently exits 0 if `current_task` is null.
+
+### 2.2 Branch + worktree creation (via create-task-branch.sh hook)
 
 ```
-Creating branch: execute/task-${id}-${slug}-${uuid}
+Branch: execute/task-${id}-${slug}-${uuid}
+Worktree: /tmp/kernel-worktrees/task-${id}-${uuid}
 ```
 
-The hook:
+When you call `Task(babyclaude, ...)`, the SubagentStart hook fires
+**synchronously** before the agent starts running. The hook:
 
-1. Verifies clean working directory
-2. Creates branch with UUID suffix
-3. Updates state with branch name
-4. Passes branch info to agent via additionalContext
+1. Reads `agent_type` from stdin; verifies it ends in `:babyclaude`.
+2. `cd`s to the project root (from hook input `cwd` field).
+3. Verifies a git repository with a clean working tree (`git diff-index --quiet HEAD`).
+4. Reads `current_task` from state (this is why step 2.1 is mandatory).
+5. Creates `execute/task-<id>-<slug>-<uuid>` branch (no checkout).
+6. Creates worktree at `/tmp/kernel-worktrees/task-<id>-<uuid>`.
+7. Updates `execute-state.json` with `tasks[i].branch` and `tasks[i].worktree_path`.
 
-### 2.2 Agent Spawning
+If the working tree is dirty, the hook exits 2 and the agent spawn is blocked.
+Ensure ephemeral state files (`execute-state.json`, `traces/`, `checkpoints/`,
+`task-outputs/`, etc.) are in `.claude/.gitignore` so editing them mid-batch
+doesn't trip this guard.
+
+> **Hooks ABI note:** The `systemMessage` JSON output from `create-task-branch.sh`
+> is NOT propagated to the spawned subagent on current Claude Code versions.
+> The agent learns its worktree path by reading state itself — see
+> `agents/babyclaude.md` Step 0. The orchestrator does NOT need to inject the
+> worktree path into the spawn prompt.
+
+### 2.3 Agent Spawning
+
+The flow is:
+
+1. Orchestrator writes `current_task` to state (step 2.1).
+2. Orchestrator calls `Task(babyclaude, ...)`.
+3. SubagentStart hook fires synchronously, creates the worktree, writes
+   `worktree_path` back to state (step 2.2).
+4. Babyclaude starts running; its system prompt's "Step 0" instructs it to read
+   `execute-state.json` and locate its own `worktree_path`. The orchestrator
+   does **not** know the worktree path before spawn and does **not** need to
+   inject it into the prompt — the hook generates a UUID that the orchestrator
+   couldn't predict anyway.
 
 **Test Task Detection:**
 
 Before spawning babyclaude, check if this is a test task:
 
 ```typescript
-const isTestTask = task.name.toLowerCase().includes('test') ||
-                   task.type === 'Test' ||
-                   task.files.some(f => f.includes('.test.') || f.includes('.spec.'));
+const isTestTask =
+  task.name.toLowerCase().includes("test") ||
+  task.type === "Test" ||
+  task.files.some((f) => f.includes(".test.") || f.includes(".spec."));
 ```
 
 **Implementation Source Injection (for test tasks):**
 
-If `isTestTask` is true, the orchestrator MUST:
-
-1. Identify dependency tasks from `task.deps`
-2. Read the implementation files from those completed dependencies
-3. Inject them into the prompt as `## Implementation Sources to Test`
+If `isTestTask` is true, the orchestrator MUST inject dependency implementation
+files into the prompt. Test tasks run against a worktree branched off `master`,
+so the dependency's output is NOT in the worktree (its branch hasn't been merged
+yet). The orchestrator needs to either inline the source contents or include a
+`cp` command for the test to access them.
 
 ```typescript
-let implementationSources = '';
+let implementationSources = "";
 
 if (isTestTask && task.deps.length > 0) {
-  // Gather implementation files from completed dependency tasks
-  const depTasks = task.deps.map(depId =>
-    state.tasks.find(t => t.id === depId)
-  ).filter(t => t && t.status === 'complete');
+  const depTasks = task.deps
+    .map((depId) => state.tasks.find((t) => t.id === depId))
+    .filter((t) => t && t.status === "completed");
 
-  const implFiles = depTasks.flatMap(t => t.files_changed || t.files);
+  // Read each dependency's output files from the dependency's worktree
+  const sources = depTasks.flatMap((dep) =>
+    (dep.files || []).map((f) => ({
+      file: f,
+      contents: readFileSync(`${dep.worktree_path}/${f}`, "utf8"),
+    })),
+  );
 
-  // Read each implementation file
   implementationSources = `
-## Implementation Sources to Test
+## Implementation Sources to Test (from dependency tasks)
 
-The following implementation files are from your dependency tasks.
-You MUST read these to understand the actual interfaces - do NOT assume or hallucinate.
+The following files are produced by your dependency tasks. They are NOT yet in
+your worktree (deps aren't merged). Copy them in from the dependency worktrees
+before running tests, e.g.:
 
-${implFiles.map(f => `- ${f}`).join('\n')}
+${depTasks.map((d) => `cp ${d.worktree_path}/*.{py,ts,js} <your-worktree>/`).join("\n")}
 
-Read these files FIRST before writing any tests.
+File contents follow so you can write the test without assuming an interface:
+
+${sources.map((s) => `### ${s.file}\n\`\`\`\n${s.contents}\n\`\`\``).join("\n\n")}
 `;
 }
 ```
 
 **Spawning babyclaude:**
 
-**CRITICAL: Worktree Isolation**
-
-The SubagentStart hook (create-task-branch.sh) creates a worktree for each task and returns the path in `additionalContext`. You MUST:
-
-1. Parse the worktree path from the hook output
-2. Pass it to babyclaude so it operates in isolation
-3. Verify babyclaude's commits go to the correct branch
-
 ```typescript
-// Get worktree path from SubagentStart hook output (stored in state)
-const worktreePath = state.tasks.find(t => t.id === task.id)?.worktree_path;
+// Step 2.1 — write current_task FIRST (mandatory)
+state.current_task = task.id;
+state.status = "executing";
+writeFileSync(stateFile, JSON.stringify(state, null, 2));
 
-if (!worktreePath) {
-  // Hook didn't create worktree - this is a bug, abort
-  throw new Error(`No worktree for task ${task.id}. Check create-task-branch.sh hook.`);
-}
-
+// Step 2.3 — call Agent. The SubagentStart hook will provision the worktree
+// synchronously before babyclaude starts. The agent reads its worktree path
+// from execute-state.json (per agents/babyclaude.md Step 0).
 Task(babyclaude, {
   prompt: `
     TASK_ID: ${task.id}
     TASK_SLUG: ${task.slug}
 
-    WORKTREE: ${worktreePath}
-    **IMPORTANT: All your file operations MUST be in the worktree directory above.**
-    Use absolute paths or cd to the worktree first.
+    Step 0 of your system prompt applies: locate your worktree by reading
+    \`current_task\` and \`tasks[].worktree_path\` from
+    ${projectDir}/.claude/execute-state.json. ALL file operations MUST happen
+    inside that worktree, not the main repo.
 
     Implement: ${task.name}
 
-    Files to modify: ${task.files.join(", ")}
+    Files to create/modify: ${task.files.join(", ")}
 
     Acceptance criteria:
     ${task.criteria.map((c) => `- ${c}`).join("\n")}
     ${implementationSources}
+
     Requirements:
-    - Work ONLY in ${worktreePath} (your isolated worktree)
     - Implement EXACTLY what is specified
     - Do NOT add features beyond the spec
-    - Commit your changes when complete
+    - Do NOT run git operations — the orchestrator owns git
     - Output JSON with status and files_changed
   `,
-  context: "fork",
-  model: "opus",
-  cwd: worktreePath, // CRITICAL: Run babyclaude in its isolated worktree
+  // NOTE: do NOT set cwd here — the hook can't communicate the worktree path
+  // back to the Agent tool before it starts the subagent. The subagent reads
+  // its worktree path from state and uses absolute paths / cd internally.
+  subagent_type: "claudikins-kernel:babyclaude",
+  model: state.model || "opus",
 });
+
+// Step 2.6 — after Agent returns, the worktree_path is in state. Read it for
+// the review phase (which needs the diff from the task branch).
+const completed = JSON.parse(readFileSync(stateFile, "utf8"));
+const worktreePath = completed.tasks.find(
+  (t) => t.id === task.id,
+)?.worktree_path;
+if (!worktreePath) {
+  throw new Error(
+    `No worktree for task ${task.id} after Agent returned. Check /tmp/kernel-hooks.log.`,
+  );
+}
 ```
 
-**Why worktree isolation matters:** Without this, parallel babyclaude agents share the same working directory. Their commits collide on whichever branch is checked out. Each agent MUST operate in its own worktree.
+**Why this flow:** The original design assumed the SubagentStart hook could pass
+the worktree path to the spawned subagent via a `systemMessage` JSON response.
+Empirically that does not propagate to the subagent's context on current Claude
+Code versions. The state-file-as-side-channel pattern works reliably and has the
+side benefit of letting the orchestrator inspect `worktree_path`, `branch`, and
+`stuck_score` at any time without parsing hook outputs.
 
-### 2.3 Branch Guard (via git-branch-guard.sh hook)
+### 2.4 Branch Guard (via git-branch-guard.sh hook)
 
 During execution, PreToolUse hook blocks:
 
@@ -392,15 +492,17 @@ During execution, PreToolUse hook blocks:
 - Direct pushes to protected branches
 - Rebasing, merging, stashing
 
-### 2.4 Progress Tracking (via execute-tracker.sh hook)
+### 2.5 Progress Tracking (via execute-tracker.sh hook)
 
-PostToolUse hook:
+PostToolUse hook (fires on every tool call inside the subagent):
 
 - Records tool calls for tracing
-- Updates stuck score
-- Warns if agent appears stuck (score >= 60)
+- Updates `tasks[i].tool_calls`, `last_tool`, `last_activity`, `stuck_score`
+- Warns if `stuck_score >= 60`
 
-### 2.5 Completion Capture (via task-completion-capture.sh hook)
+**Atomicity note:** The hook updates state via `jq ... > state.tmp && mv state.tmp state`. Earlier versions of the hook ran `mv` unconditionally even when `jq` failed, which silently truncated `execute-state.json` to 0 bytes. The current hook validates the `.tmp` is non-empty and parses as JSON before swapping it in. If you see state vanish mid-batch, check `/tmp/kernel-hooks.log` for `execute-tracker: WARNING` lines.
+
+### 2.6 Completion Capture (via task-completion-capture.sh hook)
 
 On SubagentStop:
 
@@ -417,15 +519,16 @@ After task completes, two-stage review:
 
 **You MUST spawn the reviewer agents. Inline reviews are VIOLATIONS.**
 
-| ✅ CORRECT | ❌ VIOLATION |
-|-----------|-------------|
-| `Task(spec-reviewer, {...})` | Creating your own compliance table |
-| `Task(code-reviewer, {...})` | "Let me verify the implementation" |
-| Reading `.claude/reviews/spec/*.json` | Writing "Verdict: PASS" yourself |
+| ✅ CORRECT                            | ❌ VIOLATION                       |
+| ------------------------------------- | ---------------------------------- |
+| `Task(spec-reviewer, {...})`          | Creating your own compliance table |
+| `Task(code-reviewer, {...})`          | "Let me verify the implementation" |
+| Reading `.claude/reviews/spec/*.json` | Writing "Verdict: PASS" yourself   |
 
 **The orchestrator does NOT review. The orchestrator SPAWNS reviewers.**
 
 Before proceeding to Phase 4 (Batch Review), verify:
+
 ```
 □ .claude/reviews/spec/{task_id}.json EXISTS
 □ .claude/reviews/code/{task_id}.json EXISTS
@@ -533,7 +636,10 @@ Results:
 
 ## Phase 5: Merge Decision
 
-For approved tasks:
+After each batch's reviews pass and the human accepts, merge the task branches
+into the base (master/main) BEFORE starting the next batch. Tasks in later
+batches depend on outputs from earlier batches — if you don't merge, the next
+batch's worktrees won't see those files.
 
 ```
 Ready to merge approved tasks.
@@ -545,6 +651,24 @@ Branches:
 Conflict check: None detected
 
 [Merge all] [Merge task 1 only] [Keep separate] [Squash merge]
+```
+
+### Between-batch state cleanup (orchestrator)
+
+After merging and before starting the next batch, the orchestrator must:
+
+```typescript
+// 1. Clear current_task so the SubagentStart hook doesn't try to provision
+//    a worktree on an unrelated subagent spawn (e.g. spec-reviewer).
+state.current_task = null;
+// 2. Advance current_batch.
+state.current_batch = nextBatch.id;
+// 3. (Optional) Remove the merged tasks' worktrees to free disk.
+//    `git worktree remove <path>` is BLOCKED by git-branch-guard.sh while
+//    status === "executing"; cleanup must happen after Phase 6 sets status
+//    to "completed", or via direct `rm -rf` of the worktree path + a follow-up
+//    `git worktree prune`.
+writeFileSync(stateFile, JSON.stringify(state, null, 2));
 ```
 
 ### Conflict Handling

--- a/hooks/batch-checkpoint-gate.sh
+++ b/hooks/batch-checkpoint-gate.sh
@@ -38,11 +38,15 @@ CHECKPOINT_FILE="$CHECKPOINTS_DIR/${CHECKPOINT_ID}.json"
 TIMESTAMP=$(date -Iseconds)
 
 # Get current execution state
-CURRENT_BATCH=$(jq -r '.current_batch // 0' "$STATE_FILE" 2>/dev/null || echo "0")
-CURRENT_TASK=$(jq -r '.current_task // null' "$STATE_FILE" 2>/dev/null || echo "null")
+# Use `-c` (compact) instead of `-r` so the output stays JSON-encoded — string
+# task IDs need to remain quoted for the subsequent `--argjson` to accept them.
+# The original `jq -r '.current_task // null'` returned bare `probe2` (no quotes)
+# for string IDs, which is invalid JSON and broke checkpointing entirely.
+CURRENT_BATCH=$(jq -c '.current_batch // 0' "$STATE_FILE" 2>/dev/null || echo "0")
+CURRENT_TASK=$(jq -c '.current_task // null' "$STATE_FILE" 2>/dev/null || echo "null")
 SESSION_ID=$(jq -r '.session_id // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
 
-# Count task statuses
+# Count task statuses (integers — -r is fine here)
 TOTAL_TASKS=$(jq -r '.tasks | length // 0' "$STATE_FILE" 2>/dev/null || echo "0")
 COMPLETED_TASKS=$(jq -r '[.tasks[] | select(.status == "completed")] | length // 0' "$STATE_FILE" 2>/dev/null || echo "0")
 IN_PROGRESS_TASKS=$(jq -r '[.tasks[] | select(.status == "in_progress")] | length // 0' "$STATE_FILE" 2>/dev/null || echo "0")

--- a/hooks/create-task-branch.sh
+++ b/hooks/create-task-branch.sh
@@ -19,41 +19,90 @@ WORKTREE_BASE="/tmp/kernel-worktrees"
 # Read input JSON from stdin
 INPUT=$(cat)
 
-# Extract agent name
-AGENT_NAME=$(echo "$INPUT" | jq -r '.agent_name // ""')
+# Diagnostic log — dump ALL keys so we can discover the real ABI
+DEBUG_LOG="/tmp/kernel-hooks.log"
+{
+    echo "=== $(date -u +%FT%TZ) create-task-branch.sh ==="
+    echo "FULL_INPUT: $INPUT"
+    echo "KEYS: $(echo "$INPUT" | jq -r 'keys | join(",")' 2>/dev/null || echo "?")"
+} >> "$DEBUG_LOG" 2>/dev/null || true
 
-# Only act on babyclaude spawns
+# The actual Claude Code SubagentStart hook ABI (empirically discovered, since
+# the published docs are wrong) provides these fields in stdin JSON:
+#   agent_id, agent_type, cwd, hook_event_name, session_id, transcript_path
+# There is NO `prompt` field — so we can't extract TASK_ID from the prompt.
+# Identify babyclaude by the `agent_type` field; the value is plugin-namespaced
+# (e.g. "claudikins-kernel:babyclaude"), so strip the namespace before checking.
+RAW_AGENT=$(echo "$INPUT" | jq -r '.agent_type // .subagent_type // .agent_name // .agentType // ""')
+AGENT_NAME="${RAW_AGENT##*:}"
+
 if [ "$AGENT_NAME" != "babyclaude" ]; then
+    {
+        echo "  -> skipped: agent_type=$RAW_AGENT (not babyclaude)"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
     exit 0
 fi
 
-# Extract task info from prompt (passed by execute command)
-# Format expected: TASK_ID: <id> TASK_SLUG: <slug>
-PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""')
-TASK_ID=$(echo "$PROMPT" | grep -oP 'TASK_ID:\s*\K[^\s]+' || echo "")
-TASK_SLUG=$(echo "$PROMPT" | grep -oP 'TASK_SLUG:\s*\K[^\s]+' || echo "unknown")
+# Identify which task is being executed. Since the prompt isn't in hook stdin,
+# the orchestrator must write `current_task` to execute-state.json before
+# spawning the agent. Read it from there.
+HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+if [ -n "$HOOK_CWD" ] && [ -f "$HOOK_CWD/.claude/execute-state.json" ]; then
+    STATE_FILE="$HOOK_CWD/.claude/execute-state.json"
+fi
 
-# If no task ID, this isn't a task execution - allow spawn
-if [ -z "$TASK_ID" ]; then
+if [ ! -f "$STATE_FILE" ]; then
+    {
+        echo "  -> skipped: no execute-state.json found"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
     exit 0
+fi
+
+TASK_ID=$(jq -r '.current_task // ""' "$STATE_FILE" 2>/dev/null || echo "")
+if [ -z "$TASK_ID" ] || [ "$TASK_ID" = "null" ]; then
+    {
+        echo "  -> skipped: current_task not set in state file"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
+    exit 0
+fi
+
+TASK_SLUG=$(jq -r --arg id "$TASK_ID" '(.tasks[] | select(.id == $id)).slug // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+
+{
+    echo "  -> task work detected: TASK_ID=$TASK_ID TASK_SLUG=$TASK_SLUG agent_type=$RAW_AGENT"
+} >> "$DEBUG_LOG" 2>/dev/null || true
+
+# CRITICAL: Hooks may execute with a cwd different from the project root. The
+# original script silently no-op'd when that happened (git commands failed,
+# exit-2 messages went to stderr nobody read). Force cwd to the project root
+# discovered from the hook input.
+if [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+    cd "$HOOK_CWD" || {
+        echo "  -> ERROR: cd to HOOK_CWD failed: $HOOK_CWD" >> "$DEBUG_LOG" 2>/dev/null || true
+        exit 2
+    }
+    {
+        echo "  -> cd to project: $HOOK_CWD (pwd=$(pwd))"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
 fi
 
 # Verify we're in a git repository
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    {
+        echo "  -> ERROR: not a git repository (pwd=$(pwd))"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
     echo "ERROR: Not in a git repository. Cannot create task branch." >&2
-    echo "" >&2
-    echo "The claudikins-kernel:execute command requires a git repository to manage task branches." >&2
-    echo "Run 'git init' first, or navigate to an existing repository." >&2
+    echo "  pwd: $(pwd)" >&2
     exit 2
 fi
 
 # Check for uncommitted changes that would prevent branch creation
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+    {
+        echo "  -> ERROR: uncommitted changes detected"
+        git status --short 2>&1 | head -5
+    } >> "$DEBUG_LOG" 2>/dev/null || true
     echo "ERROR: Uncommitted changes detected. Cannot create task branch." >&2
-    echo "" >&2
-    echo "Please commit or stash your changes before running claudikins-kernel:execute:" >&2
-    echo "  git stash        # Temporarily store changes" >&2
-    echo "  git commit -am 'WIP'  # Commit changes" >&2
     exit 2
 fi
 
@@ -68,16 +117,25 @@ mkdir -p "$WORKTREE_BASE"
 WORKTREE_PATH="${WORKTREE_BASE}/task-${TASK_ID}-${UUID_SUFFIX}"
 
 # Create branch first (without checkout - we'll use worktree)
-if ! git branch "$BRANCH_NAME" 2>/dev/null; then
-    # Branch might already exist from a previous failed attempt - that's ok
+BRANCH_OUTPUT=$(git branch "$BRANCH_NAME" 2>&1) || {
     if ! git rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+        {
+            echo "  -> ERROR: git branch failed: $BRANCH_OUTPUT"
+        } >> "$DEBUG_LOG" 2>/dev/null || true
         echo "ERROR: Failed to create branch: $BRANCH_NAME" >&2
+        echo "  git output: $BRANCH_OUTPUT" >&2
         exit 2
     fi
-fi
+}
+{
+    echo "  -> branch ready: $BRANCH_NAME"
+} >> "$DEBUG_LOG" 2>/dev/null || true
 
 # Create worktree for the branch
 if GIT_OUTPUT=$(git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>&1); then
+    {
+        echo "  -> worktree created: $WORKTREE_PATH"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
     # Update state file with branch and worktree info
     if [ -f "$STATE_FILE" ]; then
         jq --arg branch "$BRANCH_NAME" --arg taskId "$TASK_ID" --arg worktree "$WORKTREE_PATH" \
@@ -94,6 +152,9 @@ EOF
     exit 0
 else
     # Worktree creation failed - cleanup branch and block
+    {
+        echo "  -> ERROR: git worktree add failed: $GIT_OUTPUT"
+    } >> "$DEBUG_LOG" 2>/dev/null || true
     git branch -D "$BRANCH_NAME" 2>/dev/null || true
 
     echo "ERROR: Failed to create worktree: $WORKTREE_PATH" >&2

--- a/hooks/execute-tracker.sh
+++ b/hooks/execute-tracker.sh
@@ -51,28 +51,48 @@ if [ ! -f "$TRACE_FILE" ]; then
     echo '{"spans": [], "tool_calls": []}' > "$TRACE_FILE"
 fi
 
-# Record tool call for tracing
-if ! jq --arg task "$CURRENT_TASK" \
+# Record tool call for tracing (same atomicity bug fix as below — never mv
+# an empty/invalid jq output over the real file).
+if jq --arg task "$CURRENT_TASK" \
    --arg tool "$TOOL_NAME" \
    --arg time "$TIMESTAMP" \
    --arg result "${TOOL_RESULT:0:200}" \
    '.tool_calls += [{"task_id": $task, "tool": $tool, "timestamp": $time, "result_preview": $result}]' \
-   "$TRACE_FILE" > "${TRACE_FILE}.tmp" 2>&1; then
+   "$TRACE_FILE" > "${TRACE_FILE}.tmp" 2>/dev/null; then
+    if [ -s "${TRACE_FILE}.tmp" ] && jq -e . "${TRACE_FILE}.tmp" >/dev/null 2>&1; then
+        mv "${TRACE_FILE}.tmp" "$TRACE_FILE"
+    else
+        rm -f "${TRACE_FILE}.tmp"
+    fi
+else
     echo "execute-tracker: WARNING - trace file update failed" >&2
+    rm -f "${TRACE_FILE}.tmp"
 fi
-mv "${TRACE_FILE}.tmp" "$TRACE_FILE" 2>/dev/null || true
 
 # Update task stats in state file
-# Increment tool call count
-if ! jq --arg taskId "$CURRENT_TASK" \
+# Increment tool call count.
+# CRITICAL: the mv MUST be inside the success branch. Original code had the
+# mv outside the `if ! jq ... ; then`, which meant a transient jq failure
+# would leave an empty .tmp file that then got mv'd over the real state file,
+# silently truncating state to 0 bytes — destroying current_task and
+# worktree_path mid-task.
+if jq --arg taskId "$CURRENT_TASK" \
    --arg tool "$TOOL_NAME" \
    '(.tasks[] | select(.id == $taskId)).tool_calls += 1 |
     (.tasks[] | select(.id == $taskId)).last_tool = $tool |
     (.tasks[] | select(.id == $taskId)).last_activity = now' \
-   "$STATE_FILE" > "${STATE_FILE}.tmp" 2>&1; then
+   "$STATE_FILE" > "${STATE_FILE}.tmp" 2>/dev/null; then
+    # Sanity-check the output is non-empty AND valid JSON before clobbering state.
+    if [ -s "${STATE_FILE}.tmp" ] && jq -e . "${STATE_FILE}.tmp" >/dev/null 2>&1; then
+        mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    else
+        echo "execute-tracker: WARNING - jq produced empty/invalid output, skipping mv" >&2
+        rm -f "${STATE_FILE}.tmp"
+    fi
+else
     echo "execute-tracker: WARNING - state file update failed" >&2
+    rm -f "${STATE_FILE}.tmp"
 fi
-mv "${STATE_FILE}.tmp" "$STATE_FILE" 2>/dev/null || true
 
 # --- Stuck Detection ---
 
@@ -103,14 +123,21 @@ if [ "$TOTAL_RECENT" -ge 15 ] && [ "$FILE_CHANGING_TOOLS" -eq 0 ]; then
     STUCK_SCORE=$((STUCK_SCORE + 50))
 fi
 
-# Update stuck score in state
-if ! jq --arg taskId "$CURRENT_TASK" \
+# Update stuck score in state (same atomicity bug pattern as above)
+if jq --arg taskId "$CURRENT_TASK" \
    --argjson score "$STUCK_SCORE" \
    '(.tasks[] | select(.id == $taskId)).stuck_score = $score' \
-   "$STATE_FILE" > "${STATE_FILE}.tmp" 2>&1; then
+   "$STATE_FILE" > "${STATE_FILE}.tmp" 2>/dev/null; then
+    if [ -s "${STATE_FILE}.tmp" ] && jq -e . "${STATE_FILE}.tmp" >/dev/null 2>&1; then
+        mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    else
+        echo "execute-tracker: WARNING - jq produced empty/invalid output for stuck-score, skipping mv" >&2
+        rm -f "${STATE_FILE}.tmp"
+    fi
+else
     echo "execute-tracker: WARNING - stuck score update failed" >&2
+    rm -f "${STATE_FILE}.tmp"
 fi
-mv "${STATE_FILE}.tmp" "$STATE_FILE" 2>/dev/null || true
 
 # Output warning if stuck score is high (but don't block)
 if [ "$STUCK_SCORE" -ge 60 ]; then

--- a/hooks/git-branch-guard.sh
+++ b/hooks/git-branch-guard.sh
@@ -60,14 +60,55 @@ fi
 #   config     - Read config (--get, --list only)
 #   commit     - Commit staged changes
 
-# Extract the git subcommand
-GIT_SUBCOMMAND=$(echo "$COMMAND" | sed -n 's/.*git\s\+\([a-z-]\+\).*/\1/p')
+# Extract the git subcommand.
+# We want the subcommand of the FIRST git invocation in the command, and we
+# must skip git's global flags (-c key=value, -C path, --git-dir=, etc.) which
+# appear between `git` and the subcommand. The original regex `.*git\s+[a-z-]+`
+# was buggy in two ways: (1) `.*` is greedy and matched the LAST `git` in
+# `cmd && git foo`, and (2) `[a-z-]+` matches `-c`, so global flags were
+# mis-classified as subcommands.
+#
+# Use Perl regex (PCRE) for non-greedy + character-class precision.
+GIT_SUBCOMMAND=$(
+    echo "$COMMAND" \
+        | grep -oP '\bgit\b(?:\s+-[a-zA-Z]+(?:=\S+|\s+\S+))*\s+\K[a-z][a-z0-9-]*' \
+        | head -n1
+)
+# Fallback to the old extraction if PCRE didn't match (e.g. unusual quoting).
+if [ -z "$GIT_SUBCOMMAND" ]; then
+    GIT_SUBCOMMAND=$(echo "$COMMAND" | sed -n 's/.*git\s\+\([a-z-]\+\).*/\1/p')
+fi
 
 # Allowlist of safe git subcommands
 case "$GIT_SUBCOMMAND" in
-    add|status|diff|log|show|ls-files|check-ignore|rev-parse|symbolic-ref|commit)
-        # These are safe - allow them
+    add|status|diff|diff-index|diff-tree|log|show|ls-files|ls-tree|check-ignore|rev-parse|rev-list|symbolic-ref|for-each-ref|branch|commit|cat-file|describe|name-rev|reflog|stash)
+        # These are read-only inspection commands plus add/commit/branch (display only).
+        # `git branch` without flags lists branches; `git branch -d/-D` (delete) is
+        # still dangerous but the regex pattern `branch -d` is caught separately.
+        # `git stash` (no subcommand) lists stashes; mutating subcommands handled below.
+        if [ "$GIT_SUBCOMMAND" = "branch" ]; then
+            if echo "$COMMAND" | grep -qE 'git\s+(?:-\S+\s+)*branch\s+-[dDmM]'; then
+                echo "BLOCKED: git branch deletion/rename during task execution" >&2
+                exit 2
+            fi
+        fi
+        if [ "$GIT_SUBCOMMAND" = "stash" ]; then
+            if echo "$COMMAND" | grep -qE 'git\s+(?:-\S+\s+)*stash\s+(push|pop|apply|drop|clear|create|store|save)'; then
+                echo "BLOCKED: git stash mutation during task execution" >&2
+                exit 2
+            fi
+        fi
         exit 0
+        ;;
+    worktree)
+        # Only allow `git worktree list` (read-only). `add`, `remove`, `prune`,
+        # `move`, `repair`, `lock`, `unlock` all mutate worktree state.
+        if echo "$COMMAND" | grep -qE 'git\s+(?:-\S+\s+)*worktree\s+list'; then
+            exit 0
+        fi
+        echo "BLOCKED: git worktree mutation during task execution" >&2
+        echo "Only 'git worktree list' is allowed; worktree lifecycle is owned by the create-task-branch hook." >&2
+        exit 2
         ;;
     config)
         # git config is safe only for reading (--get, --list, --get-all, --get-regexp)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -74,12 +74,7 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/trace-start.sh",
             "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "babyclaude",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/create-task-branch.sh",
@@ -96,6 +91,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/trace-end.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/task-completion-capture.sh",
+            "timeout": 30
           }
         ]
       }

--- a/hooks/task-completion-capture.sh
+++ b/hooks/task-completion-capture.sh
@@ -18,10 +18,35 @@ OUTPUTS_DIR="$CLAUDE_DIR/task-outputs"
 # Read input JSON from stdin
 INPUT=$(cat)
 
-# Extract agent info
-AGENT_NAME=$(echo "$INPUT" | jq -r '.agent_name // ""')
-AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // ""')
-TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.agent_transcript_path // ""')
+# Diagnostic log — dump ALL keys
+DEBUG_LOG="/tmp/kernel-hooks.log"
+{
+    echo "=== $(date -u +%FT%TZ) task-completion-capture.sh ==="
+    echo "FULL_INPUT: $INPUT"
+    echo "KEYS: $(echo "$INPUT" | jq -r 'keys | join(",")' 2>/dev/null || echo "?")"
+} >> "$DEBUG_LOG" 2>/dev/null || true
+
+# Extract IDs and agent type from hook input. Claude Code SubagentStop input
+# (empirically) contains: agent_id, agent_transcript_path, agent_type, cwd,
+# hook_event_name, last_assistant_message, session_id, transcript_path, etc.
+# The agent_type field is plugin-namespaced (e.g. "claudikins-kernel:babyclaude").
+AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // .agentId // ""')
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.agent_transcript_path // .transcript_path // ""')
+RAW_AGENT=$(echo "$INPUT" | jq -r '.agent_type // .subagent_type // .agent_name // .agentType // ""')
+
+# Fallback: derive from <transcript>.meta.json if the field is missing.
+if [ -z "$RAW_AGENT" ] && [ -n "$TRANSCRIPT_PATH" ]; then
+    META_PATH="${TRANSCRIPT_PATH%.jsonl}.meta.json"
+    if [ -f "$META_PATH" ]; then
+        RAW_AGENT=$(jq -r '.agentType // .agent_type // ""' "$META_PATH" 2>/dev/null || echo "")
+    fi
+fi
+
+AGENT_NAME="${RAW_AGENT##*:}"  # strip plugin namespace prefix
+
+{
+    echo "  -> agent_id=$AGENT_ID agent_type=$RAW_AGENT (resolved=$AGENT_NAME)"
+} >> "$DEBUG_LOG" 2>/dev/null || true
 
 # Only act on babyclaude completions
 if [ "$AGENT_NAME" != "babyclaude" ]; then

--- a/hooks/trace-end.sh
+++ b/hooks/trace-end.sh
@@ -8,19 +8,33 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 TRACES_DIR="${PROJECT_DIR}/.claude/traces"
 TRACE_FILE="${TRACES_DIR}/current-trace.json"
 
-# Read hook input
-HOOK_INPUT="${CLAUDE_HOOK_INPUT:-}"
+# Read hook input from stdin (documented ABI); fall back to env var for compat.
+if [[ -t 0 ]]; then
+    HOOK_INPUT="${CLAUDE_HOOK_INPUT:-}"
+else
+    HOOK_INPUT="$(cat)"
+    if [[ -z "$HOOK_INPUT" ]]; then
+        HOOK_INPUT="${CLAUDE_HOOK_INPUT:-}"
+    fi
+fi
 if [[ -z "$HOOK_INPUT" ]]; then
     exit 0
 fi
+
+# Diagnostic log
+DEBUG_LOG="/tmp/kernel-hooks.log"
+{
+    echo "=== $(date -u +%FT%TZ) trace-end.sh ==="
+    echo "$HOOK_INPUT" | jq -c '. | {hook_event_name, subagent_type, agentId, agent_id}' 2>/dev/null || echo "raw: $HOOK_INPUT"
+} >> "$DEBUG_LOG" 2>/dev/null || true
 
 # Check trace file exists
 if [[ ! -f "$TRACE_FILE" ]]; then
     exit 0
 fi
 
-# Extract agent info
-AGENT_ID=$(echo "$HOOK_INPUT" | jq -r '.agentId // "unknown"')
+# Extract agent info. Empirical ABI uses snake_case: `agent_id`.
+AGENT_ID=$(echo "$HOOK_INPUT" | jq -r '.agent_id // .agentId // "unknown"')
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 TIMESTAMP_MS=$(date +%s%3N)
 

--- a/hooks/trace-start.sh
+++ b/hooks/trace-start.sh
@@ -11,15 +11,33 @@ TRACE_FILE="${TRACES_DIR}/current-trace.json"
 # Ensure traces directory exists
 mkdir -p "$TRACES_DIR"
 
-# Read hook input
-HOOK_INPUT="${CLAUDE_HOOK_INPUT:-}"
+# Read hook input. Claude Code delivers hook input via stdin as JSON; the env-var
+# form (CLAUDE_HOOK_INPUT) is not part of the documented ABI, so prefer stdin and
+# fall back to the env var only if stdin is empty (for forward/backward compat).
+if [[ -t 0 ]]; then
+    HOOK_INPUT="${CLAUDE_HOOK_INPUT:-}"
+else
+    HOOK_INPUT="$(cat)"
+    if [[ -z "$HOOK_INPUT" ]]; then
+        HOOK_INPUT="${CLAUDE_HOOK_INPUT:-}"
+    fi
+fi
 if [[ -z "$HOOK_INPUT" ]]; then
     exit 0
 fi
 
-# Extract agent info
-AGENT_NAME=$(echo "$HOOK_INPUT" | jq -r '.agentType // "unknown"')
-AGENT_ID=$(echo "$HOOK_INPUT" | jq -r '.agentId // "unknown"')
+# Diagnostic log
+DEBUG_LOG="/tmp/kernel-hooks.log"
+{
+    echo "=== $(date -u +%FT%TZ) trace-start.sh ==="
+    echo "$HOOK_INPUT" | jq -c '. | {hook_event_name, subagent_type, agent_name, agentType, agentId}' 2>/dev/null || echo "raw: $HOOK_INPUT"
+} >> "$DEBUG_LOG" 2>/dev/null || true
+
+# Extract agent info. Empirical ABI: field is `agent_type` (snake_case),
+# plugin-namespaced (e.g. "claudikins-kernel:babyclaude").
+RAW_AGENT=$(echo "$HOOK_INPUT" | jq -r '.agent_type // .subagent_type // .agentType // .agent_name // "unknown"')
+AGENT_NAME="${RAW_AGENT##*:}"
+AGENT_ID=$(echo "$HOOK_INPUT" | jq -r '.agent_id // .agentId // "unknown"')
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Get or create session ID


### PR DESCRIPTION
Fixes #8.

## Summary

`/claudikins-kernel:execute` is non-functional on Claude Code 2.1.141: the `SubagentStart` hook silently no-ops, no worktree is provisioned, and the orchestrator deadlocks against `git-branch-guard`. Root cause is wrong hook ABI field names; once SubagentStart exits 0 every downstream symptom looks unrelated.

This PR fixes 13 bugs across hooks, agent prompt, and the orchestrator command doc. End-to-end verified with a two-batch isolation test plus a 7-tool-call atomicity probe.

See issue #8 for the full bug-by-bug breakdown and the empirical hook ABI I discovered.

## Files touched

| File                               | Why                                                                                                                                                                                                                                            |
| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `hooks/create-task-branch.sh`      | Read `.agent_type` (not `.agent_name`); cd to project root; read TASK_ID from `execute-state.json:current_task` (not `.prompt` which doesn't exist in SubagentStart input); step-by-step diagnostic logging                                    |
| `hooks/trace-start.sh`             | Read stdin (not `CLAUDE_HOOK_INPUT` env var); use `.agent_type` / `.agent_id`                                                                                                                                                                  |
| `hooks/trace-end.sh`               | Same as trace-start.sh                                                                                                                                                                                                                         |
| `hooks/task-completion-capture.sh` | Field-name fix + `<transcript>.meta.json` sidecar fallback                                                                                                                                                                                     |
| `hooks/hooks.json`                 | Matcher `"babyclaude"` → `"*"` (plugin-namespaced agent types don't match bare); wire `task-completion-capture.sh` into SubagentStop (was unwired)                                                                                             |
| `hooks/git-branch-guard.sh`        | Fix greedy regex that matched LAST git invocation and treated `-c key=val` as a subcommand; expand allowlist for read-only inspection commands                                                                                                 |
| **`hooks/execute-tracker.sh`**     | **CRITICAL**: three call sites had `if ! jq...; then warn; fi; mv .tmp file` with **unconditional** mv. Any jq failure truncated `execute-state.json` to 0 bytes mid-batch. Moved `mv` inside success branch with non-empty + valid-JSON gate. |
| `hooks/batch-checkpoint-gate.sh`   | `jq -r` stripped quotes from string task IDs, breaking `--argjson`. Use `jq -c`.                                                                                                                                                               |
| `agents/babyclaude.md`             | Add Step 0 — agent reads its own `worktree_path` from state (the original design relied on `{"systemMessage":"..."}` reaching the subagent, which doesn't happen on current Claude Code)                                                       |
| `commands/execute.md`              | Rewrite Phase 2 to match actual hook flow: 2.1 orchestrator writes `current_task` BEFORE spawn; 2.2 hook creates worktree; 2.3 agent self-locates via Step 0. Add gitignore pre-flight, between-batch cleanup, atomicity note.                 |

## Verification

Ran `/claudikins-kernel:execute` against a real two-task plan after patches:

```
Batch 1 (hello.py):
  worktree: /tmp/kernel-worktrees/task-1-fbd641db/   ✓ created
  branch:   execute/task-1-create-hello-py-fbd641db  ✓ created
  file:     /tmp/kernel-worktrees/task-1-fbd641db/hello.py   ✓
  main repo: clean — no .py files written there       ✓
  state:    worktree_path + branch recorded           ✓

Batch 2 (test_hello.py, depends on Task 1):
  worktree: /tmp/kernel-worktrees/task-2-97d0832f/   ✓ created
  test:     python3 -m unittest test_hello.py → OK    ✓

Atomicity probe (stress execute-tracker on 7 tool calls):
  execute-state.json size: 938 bytes → 2110 bytes
  Never hit 0 bytes                                  ✓
```

`/tmp/kernel-hooks.log` shows every hook firing with `agent_type`, `TASK_ID`, and step-by-step progress. Diagnostic logging is preserved in this PR so the next debugging session takes 30 seconds not an afternoon.

## Test plan for reviewers

- [ ] `/reload-plugins` after pulling.
- [ ] Add `.claude/.gitignore` per pre-flight section in updated `commands/execute.md`.
- [ ] Run `/claudikins-kernel:outline` + `/claudikins-kernel:execute` on a trivial 2-task plan.
- [ ] Verify `/tmp/kernel-worktrees/task-<id>-*/` is created and the agent writes there.
- [ ] Verify `execute-state.json` retains `worktree_path` and never truncates during a batch.
- [ ] Tail `/tmp/kernel-hooks.log` to watch the flow.

## Out of scope (worth follow-up issues)

- `capture-catastrophiser.sh`, `capture-cynic.sh`, `capture-perfectionist.sh`, `capture-research.sh` almost certainly have the same `.agent_name` bug — they're verify/ship workflow hooks, not exercised in the execute path. Same one-line fix applies to each.
- `systemMessage` propagation: if Claude Code starts propagating SubagentStart `systemMessage` responses to the spawned subagent, Step 0 in `babyclaude.md` becomes a defensive fallback. No harm leaving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
